### PR TITLE
Fixing app dependencies

### DIFF
--- a/quickblox_api.gemspec
+++ b/quickblox_api.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'faraday'
+  spec.add_dependency 'ruby-hmac'
   spec.add_development_dependency 'bundler', '~> 1.10'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec'

--- a/quickblox_api.gemspec
+++ b/quickblox_api.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency 'faraday'
   spec.add_development_dependency 'bundler', '~> 1.10'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec'
-  spec.add_development_dependency 'faraday'
 end


### PR DESCRIPTION
I removed `faraday` from being a dev_dependency to being a full dependency because it's being used majorly in several places to make calls to the quickblox api. 

I also added `ruby-hmac` as a dependency because the gems' usage throws the error: `no such file to load -- hmac-sha1` without it. 

Kindly review. 